### PR TITLE
docker logs based on pattern match

### DIFF
--- a/roles/aws.ec2-autoscaling-group/files/etc/profile.d/99-dockercmd.sh
+++ b/roles/aws.ec2-autoscaling-group/files/etc/profile.d/99-dockercmd.sh
@@ -35,16 +35,16 @@ function dlogp {
 # Similar to dlogp but the logs are followed (docker logs -f)
 #
 # Example:
-#   $ dlogpf topics         # follow logs for a container that has 'topics' in it's image name
-function dlogpf {
-  dlogc $1 -f;
+#   $ dlogfp topics         # follow logs for a container that has 'topics' in it's image name
+function dlogfp {
+  dlogp $1 -f;
 }
 
 # Similar to dlogp but the logs are tailed (docker logs -t)
 #
 # Example:
-#   $ dlogpt topics         # tail logs for a container that has 'topics' in it's image name
-function dlogpt {
+#   $ dlogtp topics         # tail logs for a container that has 'topics' in it's image name
+function dlogtp {
   dlogp $1 -f;
 }
 

--- a/roles/aws.ec2-autoscaling-group/files/etc/profile.d/99-dockercmd.sh
+++ b/roles/aws.ec2-autoscaling-group/files/etc/profile.d/99-dockercmd.sh
@@ -10,9 +10,9 @@ alias dlogt='dlog -t'
 # The pattern match happens on the 'docker ps' command output, so you can search for
 # container id, image name, status, etc.
 # Examples:
-#       $ dlogp topics  # match on image name
-#       $ dlogp kafka   # match on image name
-#       $ dlogp 8002    # match on ports
+#       $ dlogp topics  # logs for a container that has 'topics' in it's image name
+#       $ dlogp kafka   # logs for a container that has 'kafka' in it's image name
+#       $ dlogp 8002    # logs for a container that has '8082' in it's ports field
 function dlogp {
   if [[ "$#" -eq "0" ]]; then
     echo "Usage: dlogp <pattern - containerid, image name, etc.>"
@@ -33,11 +33,17 @@ function dlogp {
 }
 
 # Similar to dlogp but the logs are followed (docker logs -f)
+#
+# Example:
+#   $ dlogpf topics         # follow logs for a container that has 'topics' in it's image name
 function dlogpf {
   dlogc $1 -f;
 }
 
 # Similar to dlogp but the logs are tailed (docker logs -t)
+#
+# Example:
+#   $ dlogpt topics         # tail logs for a container that has 'topics' in it's image name
 function dlogpt {
   dlogp $1 -f;
 }

--- a/roles/aws.ec2-autoscaling-group/files/etc/profile.d/99-dockercmd.sh
+++ b/roles/aws.ec2-autoscaling-group/files/etc/profile.d/99-dockercmd.sh
@@ -1,9 +1,47 @@
 alias watch='watch '
 alias dps='docker ps'
-function dl { (docker ps | fgrep 'aws.com/kafka:' | awk '{print $1}'; docker ps -l -q) | head -1;}
-function dlog { x="$(dl)"; if [ -z "$x" ]; then echo "Container not running."; else docker logs "$@" $x; fi ;}
+
+function dl { docker ps -lq; }
+function dlog { x="$(dl)"; if [ -z "$x" ]; then echo "No containers running."; else docker logs "$@" $x; fi ;}
 alias dlogf='dlog -f'
 alias dlogt='dlog -t'
+
+# Show docker logs for a container that matches the provided pattern.
+# The pattern match happens on the 'docker ps' command output, so you can search for
+# container id, image name, status, etc.
+# Examples:
+#       $ dlogp topics  # match on image name
+#       $ dlogp kafka   # match on image name
+#       $ dlogp 8002    # match on ports
+function dlogp {
+  if [[ "$#" -eq "0" ]]; then
+    echo "Usage: dlogp <pattern - containerid, image name, etc.>"
+    return 1
+  fi
+
+  read -r -a CONTAINERS <<< $(docker ps | grep $1 | awk '{print $1}')
+  if [[ "${#CONTAINERS[@]}" -eq "1" ]]; then
+    # Found one container matching $1
+    shift
+    docker logs "$@" ${CONTAINERS[0]}
+  elif [[ "${#CONTAINERS[@]}" -eq "0" ]]; then
+    echo "No container matching $1"
+  else
+    echo "${#CONTAINERS[@]} containers matching $1"
+    docker ps | grep "$1"
+  fi
+}
+
+# Similar to dlogp but the logs are followed (docker logs -f)
+function dlogpf {
+  dlogc $1 -f;
+}
+
+# Similar to dlogp but the logs are tailed (docker logs -t)
+function dlogpt {
+  dlogp $1 -f;
+}
+
 function dex { x="$(dl)"; if [ -z "$x" ]; then echo "Container not running."; else docker exec -it $x "$@"; fi ;}
 function dattach { x="$(dl)"; if [ -z "$x" ]; then echo "Container not running."; else docker attach --no-stdin --sig-proxy=false $x "$@"; fi ;}
 alias di='docker images'

--- a/roles/aws.ec2-autoscaling-group/files/etc/profile.d/99-dockercmd.sh
+++ b/roles/aws.ec2-autoscaling-group/files/etc/profile.d/99-dockercmd.sh
@@ -12,7 +12,7 @@ alias dlogt='dlog -t'
 # Examples:
 #       $ dlogp topics  # logs for a container that has 'topics' in it's image name
 #       $ dlogp kafka   # logs for a container that has 'kafka' in it's image name
-#       $ dlogp 8002    # logs for a container that has '8082' in it's ports field
+#       $ dlogp 8082    # logs for a container that has '8082' in it's ports field
 function dlogp {
   if [[ "$#" -eq "0" ]]; then
     echo "Usage: dlogp <pattern - containerid, image name, etc.>"


### PR DESCRIPTION
add dlogp command that lets one look at docker logs for a container based on a pattern (grep)