### PR TITLE
Shellcheck Episode One

### DIFF
--- a/ANSIBLE_DOCKER_ENV
+++ b/ANSIBLE_DOCKER_ENV
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 export ANSIBLE_BRANCH=devel
 export ANSIBLE_VERSION=2.3.0
 export ANSIBLE_COMMIT_HASH=829c0b8f6284ec37e36f1454d7d3640415239cb2

--- a/editvault.sh
+++ b/editvault.sh
@@ -1,16 +1,35 @@
 #!/usr/bin/env bash
+#
+# NAME
+#     editvault.sh - Edit ansible vault contents
+#
+# SYNOPSIS
+#     ./editvault.sh services CLUSTER SERVICE ENV
+#     ./editvault.sh infrastructure CLUSTER ENV
+
+set -eu -o pipefail
 source ANSIBLE_DOCKER_ENV
 
-SERVICE_OR_CLUSTER_PARAM=$1
-CLUSTER_NAME_PARAM=$2
+USAGE=$(sed -E -e '/^$/q' -e 's/^#($|!.*| (.*))$/\2/' "$0")
 
-if [ $SERVICE_OR_CLUSTER_PARAM = "services" ]
+SERVICE_OR_CLUSTER_PARAM=${1:?"Required argument missing. $USAGE"}
+CLUSTER_NAME_PARAM=${2:?"Required argument missing. $USAGE"}
+
+if [ "$SERVICE_OR_CLUSTER_PARAM" = "services" ]
 then
-    SERVICE_NAME_PARAM=$3
-    TARGET_ENV_PARAM=$4
-    docker run -it -v "$(pwd):/project" -v ~/.aws:/root/.aws -e TARGET_ENV=$TARGET_ENV_PARAM -e CLUSTER_NAME=$CLUSTER_NAME_PARAM -e SERVICE_NAME=$SERVICE_NAME_PARAM simplemachines/ansible-template:$DOCKER_TAG scripts/editvault-services.sh
+    SERVICE_NAME_PARAM=${3:?"Required argument missing. $USAGE"}
+    TARGET_ENV_PARAM=${4:?"Required argument missing. $USAGE"}
+    docker run -it -v "$(pwd):/project" -v ~/.aws:/root/.aws \
+        -e "TARGET_ENV=$TARGET_ENV_PARAM" \
+        -e "CLUSTER_NAME=$CLUSTER_NAME_PARAM" \
+        -e "SERVICE_NAME=$SERVICE_NAME_PARAM" \
+        "simplemachines/ansible-template:$DOCKER_TAG" \
+        scripts/editvault-services.sh
 else
-    TARGET_ENV_PARAM=$3
-    docker run -it -v "$(pwd):/project" -v ~/.aws:/root/.aws -e TARGET_ENV=$TARGET_ENV_PARAM -e CLUSTER_NAME=$CLUSTER_NAME_PARAM simplemachines/ansible-template:$DOCKER_TAG scripts/editvault-infrastructure.sh
+    TARGET_ENV_PARAM=${3:?"Required argument missing. $USAGE"}
+    docker run -it -v "$(pwd):/project" -v ~/.aws:/root/.aws \
+        -e "TARGET_ENV=$TARGET_ENV_PARAM" \
+        -e "CLUSTER_NAME=$CLUSTER_NAME_PARAM" \
+        "simplemachines/ansible-template:$DOCKER_TAG" \
+        scripts/editvault-infrastructure.sh
 fi
-


### PR DESCRIPTION
- Make `shellcheck(1)` happy with `editvault.sh`.
- `editvault.sh` reports errors when arguments are not supplied.