### PR TITLE
Add cloudwatch-log-group custom-services task

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,20 @@ Writing custom tasks is easy.
 
 Please note custom tasks are run *before* the ELB, ECR and ECS module.
 
+### CloudWatch Log Groups
+
+You can use the `cloudwatch_log_group.yml` custom task to create a log
+group:
+
+````
+cloudwatch_log_group_name: "{{ cloudwatch_log_group_name_env }}
+custom_task_files:
+  - cloudwatch_log_group.yml
+````
+
+This will create a log group with the specified name and set the
+`cloudwatch_log_group_arn` variable with the ARN of the log group.
+
 # EC2 Instances Shortcuts (alias and functions)
 
 - `dps`: shortcut for docker ps

--- a/roles/custom-services/tasks/cloudwatch_log_group.yml
+++ b/roles/custom-services/tasks/cloudwatch_log_group.yml
@@ -1,0 +1,34 @@
+---
+- name: "Create CloudWatch log group if required"
+  register: _cloudwatch_log_group_create
+  changed_when: "'CREATED' in _cloudwatch_log_group_create.stderr"
+  shell: |
+    set -eu
+    REGION="{{ aws_region }}"
+    PROFILE="{{ aws_profile }}"
+    [ -z "{{ cloudwatch_log_group_name }}" ] && exit 1
+
+    # Check whether it already exists.
+    arn=$(aws logs describe-log-groups \
+            --region "$REGION" --profile "$PROFILE"  --output text \
+            --max-items 1 --log-group-name-prefix "{{ cloudwatch_log_group_name }}" \
+          | awk '$4 == "{{ cloudwatch_log_group_name }}" { print $2 }')
+
+    if [ -n "$arn" ]; then
+      echo "UNCHANGED " > /dev/stderr
+      echo "$arn"
+    else
+      aws logs create-log-group \
+        --region "$REGION" --profile "$PROFILE"  --output text \
+        --log-group-name "{{ cloudwatch_log_group_name }}"
+      echo "CREATED " > /dev/stderr
+      aws logs describe-log-groups \
+        --region "$REGION" --profile "$PROFILE"  --output text \
+        --max-items 1 --log-group-name-prefix "{{ cloudwatch_log_group_name }}" \
+      | awk '$4 == "{{ cloudwatch_log_group_name }}" { print $2 }'
+    fi
+
+- name: "Register CloudWatch log group ARN fact"
+  when: _cloudwatch_log_group_create|succeeded
+  set_fact:
+    cloudwatch_log_group_arn: "{{ _cloudwatch_log_group_create['stdout'] }}"


### PR DESCRIPTION
Add a custom service task to create a CloudWatch log group with a given name if it does not exist.

Registers the `cloudwatch_log_group_arn` variable containing the ARN of the log group.