### PR TITLE
Allow ecs_ecr to create multiple repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,38 @@ Please note that the `cluster_name` and `service_name` are set at runtime and th
 
 Variables can be common (common.yml) to all environments or specific to dev/test/prod (dev.yml, test.yml, prod.yml, etc).
 
+## ECR
+
+To create one or more ECR repositories, place `ecr_create: true` in
+`common.yml`. The module will create a new ECR repository for each
+value in the `{{ ecr_repository_name }}` variable. This can either be
+a single value or a list of values.
+
+````
+ecr_repository_name: "{{ service_name }}"
+````
+
+or
+
+````
+ecr_repository_name:
+  - "{{ service_name }}/container1"
+  - "{{ service_name }}/container2"
+  - "{{ service_name }}/container3"
+````
+
+To use images in an ECR repository you might like to specify it like
+so in your containter definitions:
+
+````
+  image: "{{ aws_account_id['stdout'] }}.dkr.ecr.{{ aws_region }}.amazonaws.com/{{ service_name }}:latest"
+````
+
+| variable name                   | importance | default          | description                                                                                      |
+|---------------------------------|------------|------------------|--------------------------------------------------------------------------------------------------|
+| ecr_repository_name             | **mandatory** |               | Name for repository *or* YAML list of names. |
+| ecr_additional_aws_account_list | medium        | []            | List of additional AWS accounts to grant access to the repository. |
+
 ## ELB
 
 To activate the creation of an ELB, place `create_elb: true` in `common.yml`.

--- a/roles/aws.ecs-ecr/tasks/main.yml
+++ b/roles/aws.ecs-ecr/tasks/main.yml
@@ -11,7 +11,9 @@
   ecs_ecr:
     region: "{{ aws_region }}"
     profile: "{{ aws_profile }}"
-    name: "{{ ecr_repository_name }}"
+    name: "{{ item }}"
     force_set_policy: "{{ ecr_force_set_policy }}"
     policy: "{{ lookup('template', 'policy.json.j2') }}"
     state: "{{ ecr_state }}"
+  with_items:
+    - "{{ ecr_repository_name }}"


### PR DESCRIPTION
I have three images in the ECS task defined by my service. Rather than split things up to be able to create three ECR repos this change handles the case when `ecr_repository_name`.

Behaviour when it is a string is the same (according to my single test).