### PR TITLE
All scripts suggest arguments

### DIFF
--- a/editvault.sh
+++ b/editvault.sh
@@ -40,14 +40,9 @@ case $# in
                "simplemachines/ansible-template:$DOCKER_TAG" \
                scripts/editvault-infrastructure.sh
 	;;
-    0)
-	# Discover clusters, services, environments
-	DISCOVERED=$(find . -maxdepth 4 -type f -name '*.yml' ! -name 'common.yml' | ( grep /services/ || true ) | cut -d/ -f2,4,5)
-	OPTIONS_CLUSTER=$(echo "$DISCOVERED" | cut -d/ -f1 | sort -u | tr "\n" "," | sed -Ee 's/,$//;s/,/, /g')
-	OPTIONS_SERVICE=$(echo "$DISCOVERED" | cut -d/ -f2 | sort -u | tr "\n" ","| sed -Ee 's/,$//;s/,/, /g')
-	OPTIONS_ENV=$(echo "$DISCOVERED" | cut -d/ -f3 | cut -d. -f1 | sort -u | tr "\n" ","| sed -Ee 's/,$//;s/,/, /g')
+    *) # Display usage along with suggested arguments
 	cat <<EOF
-$USAGE
+ERROR: $0 requires 2 or 3 arguments; $# provided. $USAGE
 
 OPTIONS
 
@@ -60,11 +55,6 @@ EOF
 	    | sed -Ee "/infrastructure/s#^./([^/]*)/infrastructure/(.*).yml#    $0 \1 \2#" \
 	    | sed -Ee "/services/s#^./([^/]*)/services/([^/]*)/(.*).yml\$#    $0 \1 \2 \3#g" \
 	    || echo "        ERROR: No clusters or services found"
-
-	echo
-	;;
-    *)
-	echo "Error: $0 requires 2 or 3 options. $USAGE"
 	exit 1
 	;;
 esac

--- a/run-infrastructure.sh
+++ b/run-infrastructure.sh
@@ -5,6 +5,8 @@
 #
 # SYNOPSIS
 #     ./run-infrastructure.sh CLUSTER ENV
+#     ./run-infrastructure.sh
+
 
 set -eu -o pipefail
 
@@ -12,9 +14,28 @@ source ANSIBLE_DOCKER_ENV
 
 USAGE=$(sed -E -e '/^$/q' -e 's/^#($|!.*| (.*))$/\2/' "$0")
 
-docker run -it -v "${PWD}:/project" \
+case $# in
+    2) docker run -it -v "${PWD}:/project" \
                 -v ~/.aws:/root/.aws \
                 -e "CLUSTER_NAME=${1:?"Required argument missing. $USAGE"}" \
                 -e "ENV=${2:?"Required argument missing. $USAGE"}" \
                 "simplemachines/ansible-template:${DOCKER_TAG:?"Required variable missing. $USAGE"}" \
                 scripts/run-infrastructure.sh
+       ;;
+    *) # Display usage along with suggested arguments
+	cat <<EOF
+Error: $0 requires 2 arguments. $USAGE
+
+OPTIONS
+
+    You may want to run one of the following commands:
+
+EOF
+
+	find . -maxdepth 4 -type f -name '*.yml' ! -name 'common.yml' | sort \
+	    | egrep '^./([^/]+/infrastructure/.*.yml)$' \
+	    | sed -Ee "/infrastructure/s#^./([^/]*)/infrastructure/(.*).yml#    $0 \1 \2#" \
+	    || echo "        ERROR: No clusters or services found"
+	exit 1
+	;;
+esac


### PR DESCRIPTION
If executed with the incorrect number of arguments editvalue.sh and run-*.sh all report the error, a usage message, and commands for all discovered clusters, services, and environments.

````
$ ./editvault.sh 
ERROR: ./editvault.sh requires 2 or 3 arguments; 0 provided. 

NAME
    editvault.sh - Edit ansible vault contents

SYNOPSIS
    ./editvault.sh CLUSTER SERVICE ENV
    ./editvault.sh CLUSTER ENV
    ./editvault.sh

OPTIONS

    You may want to run one of the following commands:

    ./editvault.sh example-cluster dev
    ./editvault.sh example-cluster ecs-nginx-proxy dev
    ./editvault.sh example-cluster postgres-example dev
    ./editvault.sh example-cluster postgres-example prod
    ./editvault.sh lol dev
    ./editvault.sh lol prod
    ./editvault.sh lol ecs-nginx-proxy dev
    ./editvault.sh lol postgres-example dev
````

````
$ ./run-service.sh 
ERROR: ./run-service.sh requires 3 arguments; 0 provided. 

NAME
    run-service.sh - Run Ansible with service configurations

SYNOPSIS
    ./run-service.sh CLUSTER SERVICE ENV

OPTIONS

    You may want to run one of the following commands:

    ./run-service.sh example-cluster ecs-nginx-proxy dev
    ./run-service.sh example-cluster postgres-example dev
    ./run-service.sh example-cluster postgres-example prod
    ./run-service.sh lol ecs-nginx-proxy dev
    ./run-service.sh lol postgres-example dev
````

````
$ ./run-infrastructure.sh 
Error: ./run-infrastructure.sh requires 2 arguments. 

NAME
    run-infrastructure.sh - Run Ansible with infrastructure configurations

SYNOPSIS
    ./run-infrastructure.sh CLUSTER ENV

OPTIONS

    You may want to run one of the following commands:

    ./run-infrastructure.sh example-cluster dev
    ./run-infrastructure.sh lol dev
    ./run-infrastructure.sh lol prod
````