### PR TITLE
Command-line suggestions should handle vault files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vaultpassword
 *.retry
 ansible-aws-infra-services-*
+# IntelliJ
+*.iml

--- a/editvault.sh
+++ b/editvault.sh
@@ -14,7 +14,6 @@ source ANSIBLE_DOCKER_ENV
 
 USAGE=$(sed -E -e '/^$/q' -e 's/^#($|!.*| (.*))$/\2/' "$0")
 
-
 case $# in
     3)
 	CLUSTER_NAME_PARAM="${1}"
@@ -50,8 +49,11 @@ OPTIONS
 
 EOF
 
-	find . -maxdepth 4 -type f -name '*.yml' ! -name 'common.yml' | sort \
+    # We'll list environments without a vault file and vault files without an environment file.
+	find . -maxdepth 4 -type f -name '*.yml' ! -name 'common.yml' \
 	    | egrep '^./([^/]+/services/[^/]+/.*.yml|[^/]+/infrastructure/.*.yml)$' \
+	    | sed -Ee "s#^(.*)[.]vault[.]yml\$#\1.yml#" \
+	    | sort -u \
 	    | sed -Ee "/infrastructure/s#^./([^/]*)/infrastructure/(.*).yml#    $0 \1 \2#" \
 	    | sed -Ee "/services/s#^./([^/]*)/services/([^/]*)/(.*).yml\$#    $0 \1 \2 \3#g" \
 	    || echo "        ERROR: No clusters or services found"

--- a/run-infrastructure.sh
+++ b/run-infrastructure.sh
@@ -7,7 +7,6 @@
 #     ./run-infrastructure.sh CLUSTER ENV
 #     ./run-infrastructure.sh
 
-
 set -eu -o pipefail
 
 source ANSIBLE_DOCKER_ENV
@@ -32,7 +31,8 @@ OPTIONS
 
 EOF
 
-	find . -maxdepth 4 -type f -name '*.yml' ! -name 'common.yml' | sort \
+    # We'll ignore vault files; we won't be able to run them anyway.
+	find . -maxdepth 4 -type f -name '*.yml' ! -name 'common.yml' ! -name '*.vault.yml' | sort \
 	    | egrep '^./([^/]+/infrastructure/.*.yml)$' \
 	    | sed -Ee "/infrastructure/s#^./([^/]*)/infrastructure/(.*).yml#    $0 \1 \2#" \
 	    || echo "        ERROR: No clusters or services found"

--- a/run-service.sh
+++ b/run-service.sh
@@ -32,7 +32,8 @@ OPTIONS
 
 EOF
 
-	find . -maxdepth 4 -type f -name '*.yml' ! -name 'common.yml' | sort \
+    # We'll ignore vault files; we won't be able to run them anyway.
+	find . -maxdepth 4 -type f -name '*.yml' ! -name 'common.yml' ! -name '*.vault.yml' | sort \
 	    | egrep '^./([^/]+/services/[^/]+/.*.yml)$' \
 	    | sed -Ee "/services/s#^./([^/]*)/services/([^/]*)/(.*).yml\$#    $0 \1 \2 \3#g" \
 	    || echo "        ERROR: No clusters or services found"


### PR DESCRIPTION
- `editvault.sh` should handle one or more of an env file and an env vault the same.

- `run-services.sh` and `run-infrastructure.sh` should just ignore vault files.

Closes #51 (I think, I can't test it as I don't have my work laptop handy)